### PR TITLE
fix some typos and github markdown flavour related issues

### DIFF
--- a/docs/devel.md
+++ b/docs/devel.md
@@ -8,6 +8,6 @@ Porto will support backward compatibility at least between minor version
 
 # How to contribute? #
 Any kind of contribution is kindly welcome!
-Ether you want to expand functionality, report a bug or add/fix the documentation,
+Either you want to expand functionality, report a bug or add/fix the documentation,
 you can make a significant investment into the Porto project.
 Please, send your pull-request/issues via github.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -51,7 +51,7 @@ All limits can be set in stopped and running states (if not specified otherwise)
 * io\_policy ([batch, normal], default normal)
 
   - normal - interactive tasks;
-  - batch - background batch tasks (currently implemented as fixed bklio limit);
+  - batch - background batch tasks (currently implemented as fixed blkio limit);
 
 # Net
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -4,11 +4,11 @@ This might be changed via net property, which isolates container from the host n
 # Properties
 
 * hostname - container hostname (man 2 gethostname)
-* net - isolate container network, synax: none | inherited | host [interface] | macvlan <master> <name> [type] [mtu] [hw] | veth <name> <bridge> [mtu] [hw] | netns <name>
+* net - isolate container network, syntax: none | inherited | host [interface] | macvlan <master> <name> [type] [mtu] [hw] | veth <name> <bridge> [mtu] [hw] | netns <name>
   - by default network is inherited from parent container (i.e. host)
   - none - no networking, except for loopback device
   - host - move host interface into container
-  - macvlan - crate macvlan from host interface <master>
+  - macvlan - create macvlan from host interface <master>
   - veth - create veth pair and add one end into <bridge> and another end into container
   - netns - use network namespace created via ip utility
 

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -14,7 +14,7 @@ Container properties define container environment, container data define contain
 * **stdout\_path** - path to the file where stdout of container will be redirected (if user redefines this property he is responsible for removal of the file); by default Porto provides some internal file which will be removed when container is stopped
 * **stderr\_path** - ditto for stderr
 * **stdin\_path** - container stdin path; by default is /dev/null
-* **stdout\_limit** - maximum number of bytes Proto will return when reading stdout/stderr data
+* **stdout\_limit** - maximum number of bytes Porto will return when reading stdout/stderr data
 * **virt\_mode** - virtualization mode:
   - *app* - (default) start process with specified user:group
   - *os* - start process with user and group set to root with limited capabilities (should be used to run lxc/docker containers)

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -284,6 +284,7 @@ Porto support hierarchical containers in two modes (to create child container us
     In this mode if child's container isolate property is set to false, it starts in the parent container namespaces (PID, filesystem, network).
 
 2. Parent container is used to set total resource limit for a set of child containers. In this case, parent container is not started explicitly and it's mode is meta:
+
         $ portoctl create meta
         $ portoctl set meta memory_limit 1073741824
         $ portoctl run meta/child1 command="sleep 1000"

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -95,7 +95,7 @@ $ sudo portoctl destroy id
 
 # Properties
 
-If for some reason container can't start, Porto returns errno of failed syscall. Use start\_errno to get it.:
+If for some reason container can't start, Porto returns errno of failed syscall. Use start\_errno to get it:
 ```
 $ portoctl create invalid
 $ portoctl set invalid command __invalid_command__
@@ -261,46 +261,43 @@ Porto supports container resource limits. For full list of supported limits look
 
 Porto support hierarchical containers in two modes (to create child container use /):
 1. Parent container is started first and runs for a long time; child containers are periodically created and destroyed. When parent container dies, all child containers are stopped:
-```
-$ portoctl run parent command="sleep 1000"
-$ portoctl run parent/child command="sleep 100" isolate=false
-$ portoctl run parent/ps command="ps aux" isolate=false
-$ portoctl get parent state
-running
-$ portoctl get parent/child state
-running
-$ portoctl get parent/ps state
-dead
-$ portoctl get parent/ps stdout
-USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-stfomic+     1  0.0  0.0   4308   684 ?        Ss   16:27   0:00 sleep 1000
-stfomic+     2  0.0  0.0   4308   608 ?        Ss   16:27   0:00 sleep 100
-stfomic+     3  0.0  0.0  19744  1968 ?        Rs   16:27   0:00 ps aux
-$ portoctl stop parent
-$ portoctl get parent/child state
-stopped
-```
+
+        $ portoctl run parent command="sleep 1000"
+        $ portoctl run parent/child command="sleep 100" isolate=false
+        $ portoctl run parent/ps command="ps aux" isolate=false
+        $ portoctl get parent state
+        running
+        $ portoctl get parent/child state
+        running
+        $ portoctl get parent/ps state
+        dead
+        $ portoctl get parent/ps stdout
+        USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+        stfomic+     1  0.0  0.0   4308   684 ?        Ss   16:27   0:00 sleep 1000
+        stfomic+     2  0.0  0.0   4308   608 ?        Ss   16:27   0:00 sleep 100
+        stfomic+     3  0.0  0.0  19744  1968 ?        Rs   16:27   0:00 ps aux
+        $ portoctl stop parent
+        $ portoctl get parent/child state
+        stopped
 
 In this mode if child's container isolate property is set to false, it starts in the parent container namespaces (PID, filesystem, network).
 
 2. Parent container is used to set total resource limit for a set of child containers. In this case, parent container is not started explicitly and it's mode is meta:
-```
-$ portoctl create meta
-$ portoctl set meta memory_limit 1073741824
-$ portoctl run meta/child1 command="sleep 1000"
-$ portoctl run meta/child2 command="sleep 1000"
-$ portoctl get meta state
-meta
-$ portoctl get meta/child1 state
-running
-$ portoctl get meta/child2 state
-running
-$ portoctl stop meta
-$ portoctl get meta/child1 state
-stopped
-$ portoctl get meta/child2 state
-stopped
-```
+        $ portoctl create meta
+        $ portoctl set meta memory_limit 1073741824
+        $ portoctl run meta/child1 command="sleep 1000"
+        $ portoctl run meta/child2 command="sleep 1000"
+        $ portoctl get meta state
+        meta
+        $ portoctl get meta/child1 state
+        running
+        $ portoctl get meta/child2 state
+        running
+        $ portoctl stop meta
+        $ portoctl get meta/child1 state
+        stopped
+        $ portoctl get meta/child2 state
+        stopped
 
 Only memory\_limit, memory\_guarantee and recharge\_on\_pgfault limits are supported for meta containers.
 
@@ -332,7 +329,7 @@ $ portoctl destroy meta
 
 # Respawn
 
-By default, Porto doesn't restart dead containers. Using respawn property its possible to make Porto restart dead containers (delay is 1s). Maximum number of respawns is limited by max\_respawn proprty (unlimited by default, -1). respawn\_count data may be used to get number of container respawns.
+By default, Porto doesn't restart dead containers. Using respawn property its possible to make Porto restart dead containers (delay is 1s). Maximum number of respawns is limited by max\_respawn property (unlimited by default, -1). respawn\_count data may be used to get number of container respawns.
 
 # Statistics
 

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -260,6 +260,7 @@ Porto supports container resource limits. For full list of supported limits look
 # Hierarchy
 
 Porto support hierarchical containers in two modes (to create child container use /):
+
 1. Parent container is started first and runs for a long time; child containers are periodically created and destroyed. When parent container dies, all child containers are stopped:
 
         $ portoctl run parent command="sleep 1000"
@@ -280,7 +281,7 @@ Porto support hierarchical containers in two modes (to create child container us
         $ portoctl get parent/child state
         stopped
 
-In this mode if child's container isolate property is set to false, it starts in the parent container namespaces (PID, filesystem, network).
+    In this mode if child's container isolate property is set to false, it starts in the parent container namespaces (PID, filesystem, network).
 
 2. Parent container is used to set total resource limit for a set of child containers. In this case, parent container is not started explicitly and it's mode is meta:
         $ portoctl create meta
@@ -299,7 +300,7 @@ In this mode if child's container isolate property is set to false, it starts in
         $ portoctl get meta/child2 state
         stopped
 
-Only memory\_limit, memory\_guarantee and recharge\_on\_pgfault limits are supported for meta containers.
+    Only memory\_limit, memory\_guarantee and recharge\_on\_pgfault limits are supported for meta containers.
 
 Meta containers have different behavior depending on isolate property:
 * isolate=true (default) - meta container starts dummy process that holds namespaces; child containers share this namespace if they have isolate=false.

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -2,7 +2,7 @@
 Porto provides "volumes" abstraction to manage disk space. Each volume is identified by full mount path. A volume can be linked to one or more containers, unlinked volume will be destroyed automatically.
 After creation a volume is linked to the container that created the volume ("/" for host). Then the container can create new links and optionally unlink the volume from itself.
 
-You can ether manually declare a mounting path for a new volume or delegate this task to Porto:
+You can either manually declare a mounting path for a new volume or delegate this task to Porto:
 ```
 $ portoctl vcreate </path/to/volume>
 ```
@@ -105,10 +105,12 @@ $ portoctl layer -L
 A tarball with a layer can be in one of two following formats:
 * overlayfs
 * aufs (used by Docker)
+
 If you want to use existing Docker images, you have two options:
 * you can import each aufs layer as a separate layer, or
 * you can merge them sequentially into one combined layer (please, refer to the portoctl layer command built-in help).
 You can find some additional information about using layers in docker2porto script, which is intended to run Docker images by Porto.
+
 # Persistency #
 * If a volume was created with auto-generated path, the data on this volume will be destroyed automatically with the volume (when the last link to the volume is dropped).
 * Otherwise, if a user has specified the path manually, Porto doesn't destroy data at this path.


### PR DESCRIPTION
Fix some typos and problem with indentation of code block inside numbered list (https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks).