### PR TITLE
Initial TravisCI build support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+os: linux
+
+language: cpp
+
+script:
+  - cmake .
+  - make
+
+compiler: gcc
+
+branches:
+  only: master
+
+sudo: required
+
+before_install:
+  - ./travis/install-build-deps.sh

--- a/travis/install-build-deps.sh
+++ b/travis/install-build-deps.sh
@@ -2,8 +2,9 @@
 
 # gcc-4.7
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository -y ppa:canonical-kernel-team/ppa
 
 sudo apt-get update -qq
-sudo apt-get install -qq g++-4.7 flex bison libtool autoconf libncurses5-dev libprotobuf-dev protobuf-compiler
+sudo apt-get install -qq g++-4.7 flex bison libtool autoconf libncurses5-dev libprotobuf-dev protobuf-compiler linux-headers-goldfish
 
 export CXX="g++-4.7" CC="gcc-4.7"

--- a/travis/install-build-deps.sh
+++ b/travis/install-build-deps.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# gcc-4.7
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
+sudo apt-get update -qq
+sudo apt-get install -qq g++-4.7 flex bison libtool autoconf libncurses5-dev libprotobuf-dev protobuf-compiler
+
+export CXX="g++-4.7" CC="gcc-4.7"


### PR DESCRIPTION
Hi!
I've tried to enable Travis CI build on my repo fork.
It was quite easy to follow these instructions - 
https://github.com/mbonaci/mbo-storm/wiki/Integrate-Travis-CI-with-your-GitHub-repo

And I created a very simple initial script to start a build on Travis workers.
But it failed due to missing defines and others compilation errors (see log https://travis-ci.org/dreamer-dead/porto/builds/79022784)

It seems that Travis is using some old Linux kernel, may be 2.6 or something with Ubuntu 12.04.
Is it possible to write some magic script that will update worker kernel? I'm not an experienced Linux user to do that.
Or it is possible to update somehow the source code to get it compile only for Travis?
Like disabling some features.

Ability to build requests on Travis will be very useful, IMHO.