### PR TITLE
Add rvalue reference ctors for TError class.

### DIFF
--- a/src/api/cpp/error.cpp
+++ b/src/api/cpp/error.cpp
@@ -1,7 +1,6 @@
 #include "error.hpp"
 
 extern "C" {
-#include <string.h>
 #include <unistd.h>
 }
 
@@ -95,13 +94,13 @@ bool TError::Deserialize(int fd, TError &error) {
     return true;
 }
 
-const TError& TError::Success() {
-    static TError e;
+const TError &TError::Success() {
+    static const TError e;
     return e;
 }
 
-const TError& TError::Queued() {
-    static TError e(EError::Queued, "Queued");
+const TError &TError::Queued() {
+    static const TError e(EError::Queued, "Queued");
     return e;
 }
 
@@ -109,7 +108,7 @@ TError TError::FromErrno(const std::string &description) {
     return TError(EError::Unknown, errno, description);
 }
 
-std::ostream& operator<<(std::ostream& os, const TError& err) {
+std::ostream &operator<<(std::ostream &os, const TError &err) {
     os << err.GetErrorName() << " (" << err.GetMsg() << ")";
     return os;
 }

--- a/src/api/cpp/error.hpp
+++ b/src/api/cpp/error.hpp
@@ -14,11 +14,17 @@ class TError {
 
 public:
     TError();
-    TError(EError e, std::string description, int eno = 0);
-    TError(EError e, int eno, std::string description);
+    TError(EError e, const std::string &description, int eno = 0);
+    TError(EError e, int eno, const std::string &description);
+
+    TError(EError e, std::string &&description, int eno = 0);
+    TError(const TError &other) = default;
+    TError(TError &&other) = default;
+    TError &operator=(TError &&other) = default;
+    TError &operator=(const TError &other) = default;
 
     // return true if non-successful
-    operator bool() const;
+    explicit operator bool() const;
 
     EError GetError() const;
     std::string GetErrorName() const;
@@ -27,8 +33,17 @@ public:
 
     static const TError& Success();
     static const TError& Queued();
+    static TError FromErrno(const std::string &description);
     friend std::ostream& operator<<(std::ostream& os, const TError& err);
 
     TError Serialize(int fd) const;
     static bool Deserialize(int fd, TError &error);
 };
+
+inline bool operator==(const TError &lhs, const TError &rhs) {
+    return lhs.GetError() == rhs.GetError() && lhs.GetErrno() == rhs.GetErrno();
+}
+
+inline bool operator!=(const TError &lhs, const TError &rhs) {
+    return lhs.GetError() != rhs.GetError() || lhs.GetErrno() != rhs.GetErrno();
+}

--- a/src/portod.cpp
+++ b/src/portod.cpp
@@ -908,7 +908,7 @@ static int MasterMain(bool respawn) {
     std::shared_ptr<TEpollLoop> ELoop = std::make_shared<TEpollLoop>();
     TError error = ELoop->Create();
     if (error)
-        return error;
+        return EXIT_FAILURE;
 
     // We want propogate mounts into containers
     error = TMount::Remount("/", MS_REC | MS_SHARED);

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -761,7 +761,7 @@ TError TTask::ChildSetHostname() {
             string host = Env->Hostname + "\n";
             TError error = f.WriteStringNoAppend(host);
             if (error)
-                return TError(EError::Unknown, error, "write(/etc/hostname)");
+                return TError(EError::Unknown, error.GetErrno(), "write(/etc/hostname)");
         }
     }
 

--- a/src/test/selftest.cpp
+++ b/src/test/selftest.cpp
@@ -4997,7 +4997,7 @@ static void TestCgroups(TPortoAPI &api) {
 
     TFolder qwerty(freezerCg);
     ExpectEq(qwerty.Exists(), true);
-    ExpectEq(qwerty.Remove(), false);
+    ExpectSuccess(qwerty.Remove());
 
     Say() << "Make sure we can remove freezed cgroups" << std::endl;
 
@@ -5081,7 +5081,7 @@ static void TestBadClient(TPortoAPI &api) {
     int fd;
     string buf = "xyz";
     alarm(sec);
-    ExpectApiSuccess(ConnectToRpcServer(config().rpc_sock().file().path(), fd));
+    ExpectSuccess(ConnectToRpcServer(config().rpc_sock().file().path(), fd));
     ExpectEq(write(fd, buf.c_str(), buf.length()), buf.length());
 
     TPortoAPI api2(config().rpc_sock().file().path(), 0);

--- a/src/test/stresstest.cpp
+++ b/src/test/stresstest.cpp
@@ -78,7 +78,7 @@ static void Create(TPortoAPI &api, const std::string &name, const std::string &c
         TFolder f(cwd);
         if (!f.Exists()) {
             TError error = f.Create(0755, true);
-            ExpectEq(error, false);
+            ExpectSuccess(error);
         }
     }
 }

--- a/src/util/unix.cpp
+++ b/src/util/unix.cpp
@@ -169,7 +169,8 @@ size_t GetTotalMemory() {
 int CreatePidFile(const std::string &path, const int mode) {
     TFile f(path, mode);
 
-    return f.WriteStringNoAppend(std::to_string(getpid()));
+    const auto& error = f.WriteStringNoAppend(std::to_string(getpid()));
+    return error ? 1 : 0;
 }
 
 void RemovePidFile(const std::string &path) {


### PR DESCRIPTION
TError is a widely used class in Porto but it lacks move-ctors and operator=.
It is possible to optimize creating and returning error values from functions.

Also I fixed operator bool to be explicit and it helps to find some strange lines.
Please, take a look.