### PR TITLE
Extract public API sub-parts as distinct classes.

### DIFF
--- a/src/api/cpp/libporto.cpp
+++ b/src/api/cpp/libporto.cpp
@@ -449,3 +449,82 @@ int TPortoAPI::ListLayers(std::vector<std::string> &layers) {
     }
     return ret;
 }
+
+TPortoAPIContainer::TPortoAPIContainer(TPortoAPI &api, const std::string &name) :
+    TPortoAPIExtentionBase(api),
+    Name(name) {
+}
+
+int TPortoAPIContainer::Create() {
+    return Api.Create(Name);
+}
+
+int TPortoAPIContainer::Destroy() {
+    return Api.Destroy(Name);
+}
+
+int TPortoAPIContainer::Start() {
+    return Api.Start(Name);
+}
+
+int TPortoAPIContainer::Stop() {
+    return Api.Stop(Name);
+}
+
+int TPortoAPIContainer::Kill(int sig) {
+    return Api.Kill(Name, sig);
+}
+
+int TPortoAPIContainer::Pause() {
+    return Api.Pause(Name);
+}
+
+int TPortoAPIContainer::Resume() {
+    return Api.Resume(Name);
+}
+
+TPortoAPIVolume::TPortoAPIVolume(TPortoAPI &api) : TPortoAPIExtentionBase(api) {}
+
+TPortoAPIVolume::TPortoAPIVolume(TPortoAPI &api, const std::string &path) :
+    TPortoAPIExtentionBase(api),
+    Path(path) {
+}
+
+int TPortoAPIVolume::Create(const std::map<std::string, std::string> &config,
+                         TVolumeDescription &result) {
+    return Api.CreateVolume(Path, config, result);
+}
+
+int TPortoAPIVolume::Create(const std::map<std::string, std::string> &config) {
+    return Api.CreateVolume(Path, config);
+}
+
+int TPortoAPIVolume::Link(const std::string &container) {
+    return Api.LinkVolume(Path, container);
+}
+
+int TPortoAPIVolume::Unlink(const std::string &container) {
+    return Api.UnlinkVolume(Path, container);
+}
+
+int TPortoAPIVolume::List(const std::string &container,
+                       std::vector<TVolumeDescription> &volumes) {
+    return Api.ListVolumes(Path, container, volumes);
+}
+
+TPortoAPILayer::TPortoAPILayer(TPortoAPI &api, const std::string &name) :
+    TPortoAPIExtentionBase(api),
+    Name(name) {
+}
+
+int TPortoAPILayer::Import(const std::string &tarball, bool merge) {
+    return Api.ImportLayer(Name, tarball, merge);
+}
+
+int TPortoAPILayer::Export(const std::string &volume, const std::string &tarball) {
+    return Api.ExportLayer(tarball, tarball);
+}
+
+int TPortoAPILayer::Remove() {
+    return Api.RemoveLayer(Name);
+}

--- a/src/api/cpp/libporto.hpp
+++ b/src/api/cpp/libporto.hpp
@@ -98,3 +98,62 @@ public:
     int RemoveLayer(const std::string &layer);
     int ListLayers(std::vector<std::string> &layers);
 };
+
+class TPortoAPIExtentionBase {
+    TPortoAPIExtentionBase(const TPortoAPIExtentionBase &) = delete;
+    void operator=(const TPortoAPIExtentionBase &) = delete;
+
+public:
+    TPortoAPIExtentionBase(TPortoAPI &api) : Api(api) {}
+
+protected:
+    TPortoAPI &Api;
+};
+
+class TPortoAPIContainer : public TPortoAPIExtentionBase {
+    const std::string Name;
+
+public:
+    TPortoAPIContainer(TPortoAPI &api, const std::string &name);
+
+    const std::string &GetName() const { return Name; }
+
+    int Create();
+    int Destroy();
+    int Start();
+    int Stop();
+    int Kill(int sig);
+    int Pause();
+    int Resume();
+};
+
+class TPortoAPIVolume : public TPortoAPIExtentionBase {
+    std::string Path;
+
+public:
+    explicit TPortoAPIVolume(TPortoAPI &api);
+    TPortoAPIVolume(TPortoAPI &api, const std::string &path);
+
+    const std::string &GetPath() const { return Path; }
+
+    int Create(const std::map<std::string, std::string> &config,
+               TVolumeDescription &result);
+    int Create(const std::map<std::string, std::string> &config);
+    int Link(const std::string &container = std::string());
+    int Unlink(const std::string &container = std::string());
+    int List(const std::string &container,
+             std::vector<TVolumeDescription> &volumes);
+};
+
+class TPortoAPILayer : public TPortoAPIExtentionBase {
+    const std::string Name;
+
+public:
+    TPortoAPILayer(TPortoAPI &api, const std::string &name);
+
+    const std::string &GetName() const { return Name; }
+
+    int Import(const std::string &tarball, bool merge = false);
+    int Export(const std::string &volume, const std::string &tarball);
+    int Remove();
+};


### PR DESCRIPTION
Here I created a couple of simple wrappers for TPortoAPI to avoid using C-style calls of main TPortoAPI class with all parameters like name or path.

Main goal of this proposal is to discuss public API design.
For instance, my code isn't 100% bullet-proof because it keeps a ref to TPortoAPI and that ref can be lost. I can make it more safe without changing interface later.

Also if such decoupling will be approved, I want to ask about C++ namespace for public Porto API.
I was forced to use ugly names like TPortoAPIContainer because there are TPortoContainer and TVolume classes in the same global namespace.
Distinct namespace like Porto or PortoAPI will be a good solution, IMHO.
Names like TProperty and TData are quite common and it could conflict with other code of the API user.

No behavior change, TPortoAPI class was untouched.