### PR TITLE
Hide some headers and prettify protobuf.{cpp,hpp}

### DIFF
--- a/src/api/cpp/libporto.cpp
+++ b/src/api/cpp/libporto.cpp
@@ -1,3 +1,8 @@
+#include <climits>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
 #include "libporto.hpp"
 #include "protobuf.hpp"
 
@@ -49,9 +54,7 @@ void TPortoAPIImpl::Cleanup() {
 }
 
 void TPortoAPIImpl::Send(rpc::TContainerRequest &req) {
-    google::protobuf::io::FileOutputStream post(Fd);
-    WriteDelimitedTo(req, &post);
-    post.Flush();
+    WriteDelimitedTo(req, Fd, true);
 }
 
 int TPortoAPIImpl::Recv(rpc::TContainerResponse &rsp) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,8 @@
 #include <iostream>
 
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
 #include "config.hpp"
 #include "protobuf.hpp"
 #include "util/unix.hpp"

--- a/src/kvalue.cpp
+++ b/src/kvalue.cpp
@@ -7,6 +7,8 @@
 #include "util/folder.hpp"
 #include "util/unix.hpp"
 
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
 extern "C" {
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -99,8 +101,7 @@ TError TKeyValueNode::Append(const kv::TNode &node) const {
         return error;
     }
     try {
-        google::protobuf::io::FileOutputStream post(fd.GetFd());
-        if (!WriteDelimitedTo(node, &post))
+        if (!WriteDelimitedTo(node, fd.GetFd()))
             error = TError(EError::Unknown, __class__ + ": protobuf write error");
     } catch (...) {
         if (config().daemon().debug())
@@ -119,8 +120,7 @@ TError TKeyValueNode::Save(const kv::TNode &node) const {
     fd = open(Path.ToString().c_str(), O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, 0755);
     TError error;
     try {
-        google::protobuf::io::FileOutputStream post(fd.GetFd());
-        if (!WriteDelimitedTo(node, &post))
+        if (!WriteDelimitedTo(node, fd.GetFd()))
             error = TError(EError::Unknown, __class__ + ": protobuf write error");
     } catch (...) {
         if (config().daemon().debug())

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -253,12 +253,8 @@ static void SendReply(std::shared_ptr<TClient> client,
         return;
     }
 
-    google::protobuf::io::FileOutputStream post(client->GetFd());
-
     if (response.IsInitialized()) {
-        if (WriteDelimitedTo(response, &post)) {
-            post.Flush();
-
+        if (WriteDelimitedTo(response, client->GetFd(), true)) {
             if (log)
                 L_RSP() << ResponseAsString(response) << " to " << *client
                         << " (request took " << client->GetRequestTime() << "ms)"

--- a/src/test/selftest.cpp
+++ b/src/test/selftest.cpp
@@ -4479,9 +4479,7 @@ static void TestSigPipe(TPortoAPI &api) {
     rpc::TContainerRequest req;
     req.mutable_list();
 
-    google::protobuf::io::FileOutputStream post(fd);
-    WriteDelimitedTo(req, &post);
-    post.Flush();
+    WriteDelimitedTo(req, fd, true);
 
     close(fd);
     WaitPortod(api);


### PR DESCRIPTION
Removed try {} catch {} around dynamic_cast, because it should just return nullptr in case of pointer cast. Exception will be thrown for reference cast.

Also fixed some names in InterruptibleInputStream and added final keyword.

I tried to hide headers like <google/protobuf/io/zero_copy_stream_impl.h> from protobuf.hpp, but then I was forced to add it to some other cpp files.
If you want to have all proto-stuff in one place, I'll revert this change.