### PR TITLE
go API: make it more gostylish

### DIFF
--- a/src/api/go/porto.go
+++ b/src/api/go/porto.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"syscall"
 
 	"github.com/golang/protobuf/proto"
 
@@ -91,7 +92,7 @@ type API interface {
 
 	Start(name string) error
 	Stop(name string) error
-	Kill(name string, sig int32) error
+	Kill(name string, sig syscall.Signal) error
 	Pause(name string) error
 	Resume(name string) error
 
@@ -242,11 +243,12 @@ func (conn *portoConnection) Stop(name string) error {
 	return err
 }
 
-func (conn *portoConnection) Kill(name string, sig int32) error {
+func (conn *portoConnection) Kill(name string, sig syscall.Signal) error {
+	signum := int32(sig)
 	req := &rpc.TContainerRequest{
 		Kill: &rpc.TContainerKillRequest{
 			Name: &name,
-			Sig:  &sig,
+			Sig:  &signum,
 		},
 	}
 	_, err := conn.performRequest(req)

--- a/src/api/go/porto.go
+++ b/src/api/go/porto.go
@@ -143,7 +143,9 @@ type portoConnection struct {
 	msg  string
 }
 
-func NewConnection() (API, error) {
+//Connect establishes connection to a Porto daemon via unix socket.
+//Close must be called when the API is not needed anymore.
+func Connect() (API, error) {
 	c, err := net.Dial("unix", portoSocket)
 	if err != nil {
 		return nil, err

--- a/src/api/go/porto_test.go
+++ b/src/api/go/porto_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"os"
 	"os/exec"
+	"syscall"
 	"testing"
 
 	"github.com/yandex/porto/src/api/go/rpc"
@@ -143,7 +144,7 @@ func TestResume(t *testing.T) {
 func TestKill(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Kill(testContainer, 15)) // Send SIGTERM
+	FailOnError(t, conn, conn.Kill(testContainer, syscall.SIGTERM))
 }
 
 func TestWait(t *testing.T) {

--- a/src/api/go/porto_test.go
+++ b/src/api/go/porto_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/yandex/porto/src/api/go/rpc"
 )
 
-func FailOnError(t *testing.T, conn *PortoConnection, err error) {
+func FailOnError(t *testing.T, conn API, err error) {
 	if err == nil {
 		if conn != nil {
 			if conn.GetLastError() != 0 {
@@ -33,8 +33,8 @@ func FailOnError(t *testing.T, conn *PortoConnection, err error) {
 	}
 }
 
-func ConnectToPorto(t *testing.T) *PortoConnection {
-	conn, err := NewPortoConnection()
+func ConnectToPorto(t *testing.T) API {
+	conn, err := NewConnection()
 	if conn == nil {
 		t.Error(err)
 		t.FailNow()
@@ -42,10 +42,10 @@ func ConnectToPorto(t *testing.T) *PortoConnection {
 	return conn
 }
 
-const test_container string = "golang_test_container"
-const test_volume string = "/tmp/golang_test_volume"
-const test_layer string = "golang_test_layer"
-const test_tarball = "/tmp/" + test_layer + ".tgz"
+const testContainer string = "golang_testContainer"
+const testVolume string = "/tmp/golang_testVolume"
+const testLayer string = "golang_testLayer"
+const testTarball = "/tmp/" + testLayer + ".tgz"
 
 func TestGetVersion(t *testing.T) {
 	conn := ConnectToPorto(t)
@@ -88,7 +88,7 @@ func TestDlist(t *testing.T) {
 func TestCreate(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Create(test_container))
+	FailOnError(t, conn, conn.Create(testContainer))
 }
 
 func TestList(t *testing.T) {
@@ -97,7 +97,7 @@ func TestList(t *testing.T) {
 	list, err := conn.List()
 	FailOnError(t, conn, err)
 	for i := range list {
-		if list[i] == test_container {
+		if list[i] == testContainer {
 			return
 		}
 	}
@@ -108,13 +108,13 @@ func TestList(t *testing.T) {
 func TestSetProperty(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.SetProperty(test_container, "command", "sleep 10000"))
+	FailOnError(t, conn, conn.SetProperty(testContainer, "command", "sleep 10000"))
 }
 
 func TestGetProperty(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	value, err := conn.GetProperty(test_container, "command")
+	value, err := conn.GetProperty(testContainer, "command")
 	FailOnError(t, conn, err)
 	if value != "sleep 10000" {
 		t.Error("Got a wrong command value")
@@ -125,34 +125,34 @@ func TestGetProperty(t *testing.T) {
 func TestStart(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Start(test_container))
+	FailOnError(t, conn, conn.Start(testContainer))
 }
 
 func TestPause(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Pause(test_container))
+	FailOnError(t, conn, conn.Pause(testContainer))
 }
 
 func TestResume(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Resume(test_container))
+	FailOnError(t, conn, conn.Resume(testContainer))
 }
 
 func TestKill(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Kill(test_container, 15)) // Send SIGTERM
+	FailOnError(t, conn, conn.Kill(testContainer, 15)) // Send SIGTERM
 }
 
 func TestWait(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	containers := []string{test_container}
+	containers := []string{testContainer}
 	container, err := conn.Wait(containers, -1)
 	FailOnError(t, conn, err)
-	if container != test_container {
+	if container != testContainer {
 		t.Error("Wait returned a wrong container")
 		t.FailNow()
 	}
@@ -161,7 +161,7 @@ func TestWait(t *testing.T) {
 func TestGetData(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	value, err := conn.GetData(test_container, "state")
+	value, err := conn.GetData(testContainer, "state")
 	FailOnError(t, conn, err)
 	if value != "dead" {
 		t.Error("Got a wrong state value")
@@ -172,15 +172,15 @@ func TestGetData(t *testing.T) {
 func TestGet(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	containers := []string{test_container}
+	containers := []string{testContainer}
 	variables := []string{"state", "exit_status"}
 	resp, err := conn.Get(containers, variables)
 	FailOnError(t, conn, err)
-	if resp[test_container]["state"].Value != "dead" {
+	if resp[testContainer]["state"].Value != "dead" {
 		t.Error("Got a wrong state value")
 		t.FailNow()
 	}
-	if resp[test_container]["exit_status"].Value != "15" {
+	if resp[testContainer]["exit_status"].Value != "15" {
 		t.Error("Got a wrong exit_status value")
 		t.FailNow()
 	}
@@ -189,13 +189,13 @@ func TestGet(t *testing.T) {
 func TestStop(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Stop(test_container))
+	FailOnError(t, conn, conn.Stop(testContainer))
 }
 
 func TestDestroy(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Destroy(test_container))
+	FailOnError(t, conn, conn.Destroy(testContainer))
 }
 
 // VolumeAPI
@@ -216,11 +216,11 @@ func TestListVolumeProperties(t *testing.T) {
 func TestCreateVolume(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	os.Remove(test_volume)
-	os.Mkdir(test_volume, 0755)
+	os.Remove(testVolume)
+	os.Mkdir(testVolume, 0755)
 	config := make(map[string]string)
 	config["private"] = "golang test volume"
-	_, err := conn.CreateVolume(test_volume, config)
+	_, err := conn.CreateVolume(testVolume, config)
 	FailOnError(t, conn, err)
 }
 
@@ -230,7 +230,7 @@ func TestListVolumes(t *testing.T) {
 	volumes, err := conn.ListVolumes("", "")
 	FailOnError(t, conn, err)
 	for i := range volumes {
-		if volumes[i].Path == test_volume {
+		if volumes[i].Path == testVolume {
 			return
 		}
 	}
@@ -241,50 +241,50 @@ func TestListVolumes(t *testing.T) {
 func TestLinkVolume(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.Create(test_container))
-	FailOnError(t, conn, conn.LinkVolume(test_volume, test_container))
+	FailOnError(t, conn, conn.Create(testContainer))
+	FailOnError(t, conn, conn.LinkVolume(testVolume, testContainer))
 }
 
 func TestExportLayer(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.ExportLayer(test_volume, "/tmp/goporto.tgz"))
+	FailOnError(t, conn, conn.ExportLayer(testVolume, "/tmp/goporto.tgz"))
 	os.Remove("/tmp/goporto.tgz")
 }
 
 func TestUnlinkVolume(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.UnlinkVolume(test_volume, test_container))
-	FailOnError(t, conn, conn.UnlinkVolume(test_volume, "/"))
-	FailOnError(t, conn, conn.Destroy(test_container))
-	os.Remove(test_volume)
+	FailOnError(t, conn, conn.UnlinkVolume(testVolume, testContainer))
+	FailOnError(t, conn, conn.UnlinkVolume(testVolume, "/"))
+	FailOnError(t, conn, conn.Destroy(testContainer))
+	os.Remove(testVolume)
 }
 
 // LayerAPI
 func TestImportLayer(t *testing.T) {
 	// Prepare tarball
-	os.Mkdir("/tmp/golang_test_tarball", 0755)
-	defer os.Remove("/tmp/golang_test_tarball")
-	os.Mkdir("/tmp/golang_test_tarball/dir", 0755)
-	defer os.Remove("/tmp/golang_test_tarball/dir")
+	os.Mkdir("/tmp/golang_testTarball", 0755)
+	defer os.Remove("/tmp/golang_testTarball")
+	os.Mkdir("/tmp/golang_testTarball/dir", 0755)
+	defer os.Remove("/tmp/golang_testTarball/dir")
 
-	cmd := exec.Command("tar", "-czf", test_tarball,
-		"/tmp/golang/test_tarball")
+	cmd := exec.Command("tar", "-czf", testTarball,
+		"/tmp/golang/testTarball")
 	err := cmd.Start()
 	if err != nil {
 		t.Error("Can't prepare test tarball")
 		t.SkipNow()
 	}
 	err = cmd.Wait()
-	defer os.Remove(test_tarball)
+	defer os.Remove(testTarball)
 
 	// Import
 	conn := ConnectToPorto(t)
 	defer conn.Close()
 
 	FailOnError(t, conn,
-		conn.ImportLayer(test_layer, test_tarball, false))
+		conn.ImportLayer(testLayer, testTarball, false))
 }
 
 func TestListLayers(t *testing.T) {
@@ -293,7 +293,7 @@ func TestListLayers(t *testing.T) {
 	layers, err := conn.ListLayers()
 	FailOnError(t, conn, err)
 	for i := range layers {
-		if layers[i] == test_layer {
+		if layers[i] == testLayer {
 			return
 		}
 	}
@@ -304,7 +304,7 @@ func TestListLayers(t *testing.T) {
 func TestRemoveLayer(t *testing.T) {
 	conn := ConnectToPorto(t)
 	defer conn.Close()
-	FailOnError(t, conn, conn.RemoveLayer(test_layer))
+	FailOnError(t, conn, conn.RemoveLayer(testLayer))
 }
 
 func TestSendRecvData(t *testing.T) {
@@ -315,11 +315,11 @@ func TestSendRecvData(t *testing.T) {
 		t.Fatalf("unable to generate random array: %v", err)
 	}
 
-	if err := SendData(buff, data); err != nil {
+	if err := sendData(buff, data); err != nil {
 		t.Fatalf("SendData returns unexpected error: %v", err)
 	}
 
-	result, err := RecvData(buff)
+	result, err := recvData(buff)
 	if err != nil {
 		t.Fatalf("RecvData returns unexpected error: %v", err)
 	}

--- a/src/api/go/porto_test.go
+++ b/src/api/go/porto_test.go
@@ -35,7 +35,7 @@ func FailOnError(t *testing.T, conn API, err error) {
 }
 
 func ConnectToPorto(t *testing.T) API {
-	conn, err := NewConnection()
+	conn, err := Connect()
 	if conn == nil {
 		t.Error(err)
 		t.FailNow()


### PR DESCRIPTION
+ Communicate with Porto via ```API``` interface instead of ```portoConnection```.
+ Remove `Porto` prefix from public methods and types as ```porto.NewConnection``` looks better than ```porto.NewPortoConnection```
+ Kill method accepts syscall.Signal
+ Bugfix: Wait accepts time.Duration as timout and doesn't ignore it
+ Wrap RPC EError to provide more information about an error