### PR TITLE
go API: bugfix in CreateVolume

### DIFF
--- a/src/api/go/porto.go
+++ b/src/api/go/porto.go
@@ -465,7 +465,12 @@ func (conn *portoConnection) ListVolumeProperties() (ret []TProperty, err error)
 func (conn *portoConnection) CreateVolume(path string, config map[string]string) (desc TVolumeDescription, err error) {
 	var properties []*rpc.TVolumeProperty
 	for k, v := range config {
-		prop := &rpc.TVolumeProperty{Name: &k, Value: &v}
+		// NOTE: `k`, `v` save their addresses during `range`.
+		// If we append pointers to them into an array,
+		// all elements in the array will be the same.
+		// So a pointer to the copy must be used.
+		name, value := k, v
+		prop := &rpc.TVolumeProperty{Name: &name, Value: &value}
 		properties = append(properties, prop)
 	}
 


### PR DESCRIPTION
A map with a volume config was not converted properly to Volume properties, because of using pointers to iteration variables. The array was filled by copies of one property depending on iteration order.