### PR TITLE
Use a more standard C++ concept instead of goto

### DIFF
--- a/src/util/path.hpp
+++ b/src/util/path.hpp
@@ -227,3 +227,20 @@ public:
     static TError Chattr(int fd, unsigned add_flags, unsigned del_flags);
     int GetMountId(void) const;
 };
+
+// Enchanced version of TFile
+// By default will remove file at the end of function scope.
+class TScopedFile: public TFile {
+    bool Preserve = false;
+
+ public:
+    void Release() {
+        Preserve = true;
+    }
+
+    ~TScopedFile() {
+        if (!Preserve) {
+            (void)RealPath().Unlink();
+        }
+    }
+};


### PR DESCRIPTION
Added a helper TScopedFile class, that will remove controlled file
unless Release() method was called.