### PR TITLE
Don't ignore errors in credentionals initialization

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -107,7 +107,9 @@ bool TConfig::LoadFile(const std::string &path) {
     return true;
 }
 
-void TConfig::Load() {
+TError TConfig::Load() {
+    TError error;
+
     LoadDefaults();
 
     if (!LoadFile("/etc/portod.conf"))
@@ -115,8 +117,15 @@ void TConfig::Load() {
 
     Verbose |= config().log().verbose();
 
-    InitCred();
+    error = InitCred();
+    if (error) {
+        L_ERR() << "Failed initialize credentials" << std::endl;
+        return error;
+    }
+
     InitCapabilities();
+
+    return error;
 }
 
 int TConfig::Test(const std::string &path) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -16,7 +16,7 @@ class TConfig : public TNonCopyable {
     bool LoadFile(const std::string &path);
 public:
     TConfig() {}
-    void Load();
+    TError Load();
     int Test(const std::string &path);
     cfg::TCfg &operator()();
 };

--- a/src/portod.cpp
+++ b/src/portod.cpp
@@ -1447,7 +1447,11 @@ int main(int argc, char **argv) {
         return EXIT_SUCCESS;
     }
 
-    config.Load();
+    TError error = config.Load();
+    if (error) {
+        std::cerr << "failed to load config" << std::endl;
+        return EXIT_FAILURE;
+    }
 
     if (cmd == "" || cmd == "daemon")
         return PortodMain();

--- a/src/util/cred.cpp
+++ b/src/util/cred.cpp
@@ -171,17 +171,22 @@ TError TCred::Apply() const {
     return TError::Success();
 }
 
-void InitCred() {
+TError InitCred() {
     TError error;
 
     error = GroupId(PORTO_GROUP_NAME, PortoGroup);
     if (error) {
-        L_WRN() << "Cannot find group porto: " << error << std::endl;
-        PortoGroup = NoGroup;
+        L_ERR() << "Cannot find group " << PORTO_GROUP_NAME << ": " << error << std::endl;
+        return error;
     }
 
-    if (GroupId(PORTO_CT_GROUP_NAME, PortoCtGroup))
-        PortoCtGroup = NoGroup;
+    error = GroupId(PORTO_CT_GROUP_NAME, PortoCtGroup);
+    if (error) {
+        L_ERR() << "Cannot find group " << PORTO_CT_GROUP_NAME << ": " << error << std::endl;
+        return error;
+    }
+
+    return error;
 }
 
 #ifndef CAP_BLOCK_SUSPEND

--- a/src/util/cred.hpp
+++ b/src/util/cred.hpp
@@ -14,7 +14,7 @@ TError FindGroups(const std::string &user, gid_t gid, std::vector<gid_t> &groups
 TError GroupId(const std::string &group, gid_t &gid);
 std::string GroupName(gid_t gid);
 
-void InitCred();
+TError InitCred();
 
 constexpr uid_t RootUser = (uid_t)0;
 constexpr gid_t RootGroup = (gid_t)0;


### PR DESCRIPTION
Current version of code ignores errors but fails later,
e.g., in mount of /run/porto/kvs.
