### PR TITLE
Fix building against GCC 7.3.0 on ubuntu 18.04

### DIFF
--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <csignal>

--- a/src/portoctl.cpp
+++ b/src/portoctl.cpp
@@ -812,7 +812,7 @@ static const map<string, int> sigMap = {
     { "SIGLOST",    SIGLOST },
 #endif
     { "SIGWINCH",   SIGWINCH },
-    { "SIGUNUSED",  SIGUNUSED },
+    { "SIGUNUSED",  SIGSYS },
 };
 
 class TKillCmd final : public ICmd {


### PR DESCRIPTION
Porto Git version does not compile on ubuntu 18.04, GCC 7.3.0.

Though, i'm not sure if I done right with SIGUNUSED:
Seems it was removed, there is no definition of it in bits/signum.h and bits/signum-generic.h anymore. I aliased it to SIGSYS which has the same number.