### PR TITLE
Fix typo and code blocks indent

### DIFF
--- a/porto.md
+++ b/porto.md
@@ -707,15 +707,16 @@ Possible indexes for statistics and parameters:
 * **resolv\_conf**   - DNS resolver configuration, syntax: default|keep|\<resolv.conf option\>;...
 
     Default setting **resolv\_conf**="default" loads configuration from portod.conf:
-```
-container { default_resolv_conf: "nameserver <ip>;nameserver <ip>;..." }
-```
+    ```
+    container { default_resolv_conf: "nameserver <ip>;nameserver <ip>;..." }
+    ```
+        
     or from host /etc/resolv.conf if option in portod.conf isn't set.
 
     Inside container root /etc/resolv.conf must be a regular file,
     porto bind-mounts temporary file over it.
 
-    Setting **resolv\_conf**="keep" keeps configuraion in container as is.
+    Setting **resolv\_conf**="keep" keeps configuration in container as is.
 
 * **sysctl**         - sysctl configuration, syntax: \<sysctl\>: \<value\>;...
 
@@ -723,20 +724,20 @@ container { default_resolv_conf: "nameserver <ip>;nameserver <ip>;..." }
 
     Default values for network and ipc sysctls are the same as in host and
     could be overriden in portod.conf:
-```
-container {
-    ipc_sysctl {
-        key: "sysctl"
-        val: "value"
-    },
-    ...
-    net_sysctl {
-        key: "sysctl"
-        val: "value"
-    },
-    ...
-}
-```
+    ```
+    container {
+        ipc_sysctl {
+            key: "sysctl"
+            val: "value"
+        },
+        ...
+        net_sysctl {
+            key: "sysctl"
+            val: "value"
+        },
+        ...
+    }
+    ```
 
 * **net\_guarantee** - required egress bandwidth: \<interface\>|group \<group\>|default: \<Bps\>;...
 
@@ -779,22 +780,22 @@ container {
 
     Porto setup first level TC classes for each CSx.
     Default class, weights and limits could be set in portod.conf:
-```
-network {
-    default_tos: "CS0"
-    dscp_class {
-        name: "CS1"
-        weight: 10
-        limit: 123456
-        max_percent: 16.5
+    ```
+    network {
+        default_tos: "CS0"
+        dscp_class {
+            name: "CS1"
+            weight: 10
+            limit: 123456
+            max_percent: 16.5
+        }
+        dscp_class {
+            name: "CS3"
+            weight: 42
+        }
+        ...
     }
-    dscp_class {
-        name: "CS3"
-        weight: 42
-    }
-    ...
-}
-```
+    ```
 
 # NETWORKING
 


### PR DESCRIPTION
Add indent for code blocks to fix markdown rendering for text after code block.